### PR TITLE
Fixed XCode export issue

### DIFF
--- a/PushwooshUnitySample/Assets/Editor/PushwooshBuildManager.cs
+++ b/PushwooshUnitySample/Assets/Editor/PushwooshBuildManager.cs
@@ -45,7 +45,7 @@ public class PushwooshBuildManager : MonoBehaviour
 
 			PBXProject proj = new PBXProject();
 			proj.ReadFromString(File.ReadAllText(projPath));
-			string projTarget = proj.TargetGuidByName("Unity-iPhone");
+			string projTarget = proj.GetUnityMainTargetGuid();
 			UnityEngine.Debug.Log ("Project Target: " + projTarget);
 
 			proj.AddFrameworkToProject(projTarget, "Security.framework", false);


### PR DESCRIPTION
Replaced deprecated `TargetGuidByName `by new `GetUnityMainTargetGuid`
The deprecated method emits an exception during export Unity build to XCode project, as a result, XCode project is corrupted and can't create a valid iOS build. New method `GetUnityMainTargetGuid` resolves the issue.