### PR TITLE
Work around a case, if oauth_client is empty

### DIFF
--- a/PushwooshUnitySample/Assets/Editor/CustomBuildProcessor.cs
+++ b/PushwooshUnitySample/Assets/Editor/CustomBuildProcessor.cs
@@ -33,8 +33,8 @@ class CustomBuildProcessor : IPreprocessBuild
             var client = dict["client"] as List<object>;
             var element = client[0] as Dictionary<string, object>;
             var oauthClient = element["oauth_client"] as List<object>;
-            var elementOathClient = oauthClient[0] as Dictionary<string, object>;
-            var clientId = elementOathClient["client_id"] as string;
+            var elementOathClient = oauthClient.Count > 0 ? oauthClient[0] as Dictionary<string, object> : null;
+            var clientId = elementOathClient != null ? elementOathClient["client_id"] as string : "";
 
             var clientInfo = element["client_info"] as Dictionary<string, object>;
             var appId = clientInfo["mobilesdk_app_id"];


### PR DESCRIPTION
If a user doesn't use Authentication in the Firebase Console (for example Google Sign-In), the google-services.json file will have an empty `oauth_client`.
Example:
<img width="228" height="107" alt="image" src="https://github.com/user-attachments/assets/d030b3c5-ebb6-476c-836d-c4ca771f2837" />

The following line and the entire script as result will fail with `ArgumentOutOfRangeException`.
```
var elementOathClient = oauthClient[0] as Dictionary<string, object>;
```

> "ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
> Parameter name: index
> System.Collections.Generic.List1[T].get_Item (System.Int32 index) (at <27bd554a9f0e46179afd19da1336e638>:0) CustomBuildProcessor.OnPreprocessBuild (UnityEditor.BuildTarget target, System.String path) (at Assets/Editor/CustomBuildProcessor.cs:36) UnityEditor.Build.BuildPipelineInterfaces+<>c__DisplayClass16_0.<OnBuildPreProcess>b__0 (UnityEditor.Build.IPreprocessBuild bpp) (at /Users/bokken/build/output/unity/unity/Editor/Mono/BuildPipeline/BuildPipelineInterfaces.cs:502) UnityEditor.Build.BuildPipelineInterfaces.InvokeCallbackInterfacesPair[T1,T2] (System.Collections.Generic.List1[T] oneInterfaces, System.Action1[T] invocationOne, System.Collections.Generic.List1[T] twoInterfaces, System.Action`1[T] invocationTwo, System.Boolean exitOnFailure) (at /Users/bokken/build/output/unity/unity/Editor/Mono/BuildPipeline/BuildPipelineInterfaces.cs:462)
> UnityEditor.EditorApplication:Internal_CallDelayFunctions() (at /Users/bokken/build/output/unity/unity/Editor/Mono/EditorApplication.cs:399)"

Pushwoosh and FCM credentials will not be passed to the xml and the device won't be able to register for push notifications.